### PR TITLE
BugFix > when column is not present in a row

### DIFF
--- a/CsvExport.cs
+++ b/CsvExport.cs
@@ -106,6 +106,10 @@ namespace Jitbit.Utils
 			// The rows
 			foreach (Dictionary<string, object> row in rows)
 			{
+				fields.Where(f => !row.ContainsKey(f)).ToList().ForEach(k =>
+		                {
+		                    row[k] = null;
+		                });
 				sb.Append(string.Join(",", fields.Select(field => MakeValueCsvFriendly(row[field])).ToArray()));
 				sb.AppendLine();
 			}


### PR DESCRIPTION
When you do not add one or more keys (or, columns) for a row which is present in other rows, this was throwing exceptions. Added fix resolves the issue.