### PR TITLE
Reduce memory usage of ExportToFile

### DIFF
--- a/CsvExport.cs
+++ b/CsvExport.cs
@@ -118,17 +118,14 @@ namespace Jitbit.Utils
 		}
 
 		/// <summary>
-		/// Output all rows as a CSV returning a string
+		/// Outputs all rows as a CSV, returning one string at a time
 		/// </summary>
-		public string Export()
+		private IEnumerable<string> ExportToLines()
 		{
-			StringBuilder sb = new StringBuilder();
-
-			sb.AppendLine("sep=,");
+			yield return "sep=,";
 
 			// The header
-			sb.Append(string.Join(",", fields.ToArray()));
-			sb.AppendLine();
+			yield return string.Join(",", fields.ToArray());
 
 			// The rows
 			foreach (Dictionary<string, object> row in rows)
@@ -137,8 +134,20 @@ namespace Jitbit.Utils
 				{
 					row[k] = null;
 				});
-				sb.Append(string.Join(",", fields.Select(field => MakeValueCsvFriendly(row[field])).ToArray()));
-				sb.AppendLine();
+				yield return string.Join(",", fields.Select(field => MakeValueCsvFriendly(row[field])).ToArray());
+			}
+		}
+
+		/// <summary>
+		/// Output all rows as a CSV returning a string
+		/// </summary>
+		public string Export()
+		{
+			StringBuilder sb = new StringBuilder();
+
+			foreach (string line in ExportToLines())
+			{
+				sb.AppendLine(line);
 			}
 
 			return sb.ToString();

--- a/CsvExport.cs
+++ b/CsvExport.cs
@@ -158,7 +158,7 @@ namespace Jitbit.Utils
 		/// </summary>
 		public void ExportToFile(string path)
 		{
-			File.WriteAllLines(path, ExportToLines());
+			File.WriteAllLines(path, ExportToLines(), Encoding.UTF8);
 		}
 
 		/// <summary>

--- a/CsvExport.cs
+++ b/CsvExport.cs
@@ -134,9 +134,9 @@ namespace Jitbit.Utils
 			foreach (Dictionary<string, object> row in rows)
 			{
 				fields.Where(f => !row.ContainsKey(f)).ToList().ForEach(k =>
-		                {
-		                    row[k] = null;
-		                });
+				{
+					row[k] = null;
+				});
 				sb.Append(string.Join(",", fields.Select(field => MakeValueCsvFriendly(row[field])).ToArray()));
 				sb.AppendLine();
 			}

--- a/CsvExport.cs
+++ b/CsvExport.cs
@@ -125,16 +125,16 @@ namespace Jitbit.Utils
 			yield return "sep=,";
 
 			// The header
-			yield return string.Join(",", fields.ToArray());
+			yield return string.Join(",", fields);
 
 			// The rows
 			foreach (Dictionary<string, object> row in rows)
 			{
-				fields.Where(f => !row.ContainsKey(f)).ToList().ForEach(k =>
+				foreach (string k in fields.Where(f => !row.ContainsKey(f)))
 				{
 					row[k] = null;
-				});
-				yield return string.Join(",", fields.Select(field => MakeValueCsvFriendly(row[field])).ToArray());
+				}
+				yield return string.Join(",", fields.Select(field => MakeValueCsvFriendly(row[field])));
 			}
 		}
 

--- a/CsvExport.cs
+++ b/CsvExport.cs
@@ -158,7 +158,7 @@ namespace Jitbit.Utils
 		/// </summary>
 		public void ExportToFile(string path)
 		{
-			File.WriteAllText(path, Export());
+			File.WriteAllLines(path, ExportToLines());
 		}
 
 		/// <summary>


### PR DESCRIPTION
The current implementation of `ExportToFile` uses a lot of memory for large CSV files because it builds the entire document in memory. This pull request uses a streaming approach to reduce the memory overhead to a constant.

Testing:
- Run the sample code before the changes and save the results to `old.csv`
- Run the sample code after the changes and save the result to `new.csv`
- Assert that there is no diff between `old.csv` and `new.csv`