### PR TITLE
Extend check for field delimiters to date/time columns

### DIFF
--- a/CsvExport.cs
+++ b/CsvExport.cs
@@ -134,13 +134,23 @@ namespace Jitbit.Utils
 		{
 			if (value == null) return "";
 			if (value is INullable && ((INullable)value).IsNull) return "";
+
+			string output;
 			if (value is DateTime)
 			{
 				if (((DateTime)value).TimeOfDay.TotalSeconds == 0)
-					return ((DateTime)value).ToString("yyyy-MM-dd");
-				return ((DateTime)value).ToString("yyyy-MM-dd HH:mm:ss");
+				{
+					output = ((DateTime)value).ToString("yyyy-MM-dd");
+				}
+				else
+				{
+					output = ((DateTime)value).ToString("yyyy-MM-dd HH:mm:ss");
+				}
 			}
-			string output = value.ToString().Trim();
+			else
+			{
+				output = value.ToString().Trim();
+			}
 			
 			if (output.Length > 30000) //cropping value for stupid Excel
 				output = output.Substring(0, 30000);


### PR DESCRIPTION
Requesting pull for a change that will extend the check CSV - friendly representation to date and time columns.

The current implementation will not add double-quotes around fields that represent a date/time value in the case where the field delimiter is part of the date or time representation (e.g. ':' or '-').