### PR TITLE
Add MIT license file

### DIFF
--- a/CsvExport/CsvExport.csproj
+++ b/CsvExport/CsvExport.csproj
@@ -7,6 +7,7 @@
 	<Authors>Alex from Jitbit</Authors>
     <Copyright>Copyright Jitbit 2017-2023</Copyright>
     <PackageProjectUrl>https://github.com/jitbit/CsvExport</PackageProjectUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/jitbit/CsvExport</RepositoryUrl>
     <Description>CSV Export component for .NET</Description>
@@ -18,6 +19,10 @@
     <None Include="..\README.md">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
+    </None>
+    <None Include="..\LICENSE">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
     </None>
   </ItemGroup>
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jitbit (the company behind "Jitbit Helpdesk" software)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,6 @@ Also, methods `ExportToFile` and `ExportAsMemoryStream` and `ExportToBytes` offe
 
 ### License
 
-The code is licensed under *MIT License*.
+The code is licensed under *[MIT License](/LICENSE)*.
 
 Sucessfully tested for years in production with our [Jitbit Helpdesk Ticketing System](https://www.jitbit.com/helpdesk/)


### PR DESCRIPTION
This adds the specified license in README as a LICENSE file in the repo, this way the license of the repo is displayed in repo overview. 
The license file was created using githubs template for the MIT License.
Also takes the opportunity to make the README entry for the license a relative link to the license file. 
And package and reference the license file for the nuget package